### PR TITLE
qrcode generate using main proccess

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -9,9 +9,14 @@ class App extends Component {
   constructor() {
     super();
     this.updateCurrent = this.updateCurrent.bind(this);
+    this.updateGeolocation = this.updateGeolocation.bind(this);
     this.state = {
       current: { country: '---', prefecture: '---', river: '---' },
       list: [{ country: '---', prefecture: '---', river: '---' }],
+      geolocation: {
+        latitude: 0,
+        longitude: 0,
+      },
       data: {
         precipitation: 0,
         trendencyPr: 0,
@@ -23,6 +28,7 @@ class App extends Component {
   }
 
   componentWillMount() {
+    this.updateGeolocation();
     ipcRenderer.on('dataReflect', (ev, data) => {
       this.setState({ data });
     });
@@ -37,10 +43,23 @@ class App extends Component {
     this.setState({ current });
   }
 
+  updateGeolocation() {
+    // ここでgeolocationを取得する
+    const geolocation = {
+      latitude: 10,
+      longitude: 10,
+    };
+    ipcRenderer.send('updateGeolocation', geolocation);
+    this.setState({ geolocation });
+  }
+
   render() {
     return (
       <div>
-        <Header current={this.state.current} />
+        <Header
+          current={this.state.current}
+          updateGeolocation={this.updateGeolocation}
+        />
         <Main {...this.state} changeLocation={this.updateCurrent} />
       </div>
     );

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -43,7 +43,7 @@ class App extends Component {
     this.setState({ current });
   }
 
-  async getGeolocation() {
+  getGeolocation() {
     if (!'geolocation' in navigator) return { latitude: 0, longitude: 0 };
 
     return new Promise((resolve, reject) => {

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -40,7 +40,7 @@ class App extends Component {
   }
 
   getGeolocation() {
-    if (!'geolocation' in navigator) return { latitude: 0, longitude: 0 };
+    if (!'geolocation' in navigator) return { latitude: 999, longitude: 999 };
 
     return new Promise((resolve, reject) => {
       navigator.geolocation.getCurrentPosition(

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -13,10 +13,6 @@ class App extends Component {
     this.state = {
       current: { country: '---', prefecture: '---', river: '---' },
       list: [{ country: '---', prefecture: '---', river: '---' }],
-      geolocation: {
-        latitude: 0,
-        longitude: 0,
-      },
       data: {
         precipitation: 0,
         trendencyPr: 0,
@@ -61,7 +57,6 @@ class App extends Component {
     try {
       const geolocation = await this.getGeolocation();
       ipcRenderer.send('updateGeolocation', geolocation);
-      this.setState({ geolocation });
     } catch (err) {
       throw err;
     }
@@ -75,8 +70,6 @@ class App extends Component {
           updateGeolocation={this.updateGeolocation}
         />
         <Main {...this.state} changeLocation={this.updateCurrent} />
-        {this.state.geolocation.latitude}<br />
-        {this.state.geolocation.longitude}
       </div>
     );
   }

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -18,6 +18,9 @@ class App extends Component {
         trendencyWl: 0,
         warning: false,
       },
+      qr: {
+        src: ""
+      }
     }
   }
 
@@ -27,6 +30,10 @@ class App extends Component {
     });
     ipcRenderer.on('locationReflect', (ev, { current, list }) => {
       this.setState({ current, list });
+    });
+    ipcRenderer.on('qrCodeReflect', (ev, qr) => {
+      console.log({ qr });
+      this.setState({ qr })
     });
   }
 

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -17,9 +17,7 @@ class App extends Component {
         trendencyPr: 0,
         trendencyWl: 0,
         warning: false,
-      },
-      qr: {
-        src: ""
+        qrSrc: '',
       }
     }
   }
@@ -30,10 +28,6 @@ class App extends Component {
     });
     ipcRenderer.on('locationReflect', (ev, { current, list }) => {
       this.setState({ current, list });
-    });
-    ipcRenderer.on('qrCodeReflect', (ev, qr) => {
-      console.log({ qr });
-      this.setState({ qr })
     });
   }
 

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -42,13 +42,20 @@ class App extends Component {
   getGeolocation() {
     if (!'geolocation' in navigator) return { latitude: 999, longitude: 999 };
 
+    const options = {
+      enableHighAccuracy: true,
+      timeout: 5000,
+      maximumAge: 0
+    };
+
     return new Promise((resolve, reject) => {
       navigator.geolocation.getCurrentPosition(
         (position) => resolve({
           latitude: position.coords.latitude,
           longitude: position.coords.longitude,
         }),
-        (err) => reject(`ERROR(${err.code}): ${err.message}`)
+        (err) => reject(`ERROR(${err.code}): ${err.message}`),
+        options,
       );
     });
   }

--- a/app/js/components/header.js
+++ b/app/js/components/header.js
@@ -4,7 +4,8 @@ import React from 'react';
 import { ipcRenderer } from 'electron';
 import getMenu from '../menu';
 
-const onRefresh = () => {
+const onRefresh = (updateGeolocation) => {
+  updateGeolocation();
   ipcRenderer.send('refresh');
 };
 
@@ -16,7 +17,13 @@ const openMenu = () => {
 const Header = (props) => {
   return (
     <header className="noah-header">
-      <i className="fa fa-refresh" aria-hidden="true" aria-label="Refresh" onClick={onRefresh}></i>
+      <i
+        className="fa fa-refresh"
+        aria-hidden="true"
+        aria-label="Refresh"
+        onClick={() => onRefresh(props.updateGeolocation)}
+      >
+      </i>
       <h1>noah</h1>
       <i className="fa fa-cog" aria-hidden="true" aria-label="Options" onClick={openMenu}></i>
     </header>

--- a/app/js/components/main.js
+++ b/app/js/components/main.js
@@ -4,6 +4,7 @@ import React from 'react';
 import Location from './location';
 import RainImage from './rainimage';
 import Data from './data';
+import QrCode from './qrcode';
 
 const Main = (props) => {
   return (
@@ -15,6 +16,7 @@ const Main = (props) => {
       />
       <RainImage data={props.data} />
       <Data data={props.data} />
+      <QrCode data={props.qr} />
     </main>
   );
 };

--- a/app/js/components/main.js
+++ b/app/js/components/main.js
@@ -16,7 +16,7 @@ const Main = (props) => {
       />
       <RainImage data={props.data} />
       <Data data={props.data} />
-      <QrCode data={props.qr} />
+      <QrCode qrSrc={props.data.qrSrc} />
     </main>
   );
 };

--- a/app/js/components/qrcode.js
+++ b/app/js/components/qrcode.js
@@ -5,8 +5,8 @@ import React from 'react';
 const QRCode = (props) => {
   return (
     <div className="noah-qrcode">
-      <p>{props.data.src}</p>
-      <img src={props.data.src} alt="QRコード" />
+      <p>{props.qrSrc}</p>
+      <img src={props.qrSrc} alt="QRコード" />
     </div>
   );
 };

--- a/app/js/components/qrcode.js
+++ b/app/js/components/qrcode.js
@@ -5,6 +5,7 @@ import React from 'react';
 const QRCode = (props) => {
   return (
     <div className="noah-qrcode">
+      <p>{props.data.src}</p>
       <img src={props.data.src} alt="QRコード" />
     </div>
   );

--- a/app/js/components/qrcode.js
+++ b/app/js/components/qrcode.js
@@ -2,11 +2,18 @@
 
 import React from 'react';
 
+const getImg = (qrSrc) => {
+  if (qrSrc === '') {
+    return <p>QRコードが表示できません</p>;
+  }
+  return <img src={qrSrc} alt="QRコード" />;
+}
+
 const QRCode = (props) => {
   return (
     <div className="noah-qrcode">
       <p>{props.qrSrc}</p>
-      <img src={props.qrSrc} alt="QRコード" />
+      {getImg(props.qrSrc)}
     </div>
   );
 };

--- a/app/js/components/qrcode.js
+++ b/app/js/components/qrcode.js
@@ -1,0 +1,13 @@
+'use strict';
+
+import React from 'react';
+
+const QRCode = (props) => {
+  return (
+    <div className="noah-qrcode">
+      <img src={props.data.src} alt="QRコード" />
+    </div>
+  );
+};
+
+export default QRCode;

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,9 +113,10 @@ module.exports = class Lib {
     return '';
   }
   getQrURL () {
-    // ここでURLを生成するロジックを書く
+    const destination = '入江タリーズ'; // TODO: 引数で受け取れるようにする
     console.log(this.geolocation.latitude, this.geolocation.longitude);
-    return `http://chart.apis.google.com/chart?chs=${this.qrsize}x${this.qrsize}&cht=qr&chl=http://lgtm.in/i/yFqM3iGVp`;
+    const chl = `https://www.google.co.jp/maps/dir/${ this.geolocation.latitude },${ this.geolocation.longitude }/${encodeURIComponent(destination)}/`;
+    return `http://chart.apis.google.com/chart?chs=${this.qrsize}x${this.qrsize}&cht=qr&chl=${chl}`;
   }
   getData () {
     // example data

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,9 +142,9 @@ module.exports = class Lib {
   polling (param, cronTime) {
     const job = new CronJob({
       cronTime,
-      onTick: () => requestWaterLevel(this.getWaterLevelURL, param),
+      onTick: () => requestWaterLevel(this.getWaterLevelURL(), param),
       start: true,
     });
     job.start();
   }
-}
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -86,6 +86,11 @@ module.exports = class Lib {
       { country: 'japan', prefecture: 'ishikawa', river: 'asano' },
       { country: 'japan', prefecture: 'tokyo', river: 'sumida' },
     ];
+    this.qrsize = 150;
+    this.geolocation = {
+      latitude: 0,
+      longitude: 0,
+    };
   }
   setCurrentLocation ({ country = this.country, prefecture = this.prefecture, river = this.river }) {
     this.country = country;
@@ -101,27 +106,26 @@ module.exports = class Lib {
   getRainFallURL () {
     return '';
   }
+  getQrURL () {
+    // ここでURLを生成するロジックを書く
+    console.log(this.geolocation.latitude, this.geolocation.longitude);
+    return `http://chart.apis.google.com/chart?chs=${this.qrsize}x${this.qrsize}&cht=qr&chl=http://lgtm.in/i/yFqM3iGVp`;
+  }
   getData () {
     // example data
     const precipitation = Math.floor(Math.random() * 999);
     const trendencyPr = Math.floor(Math.random() * 5);
     const trendencyWl = Math.floor(Math.random() * 5);
     const warning = getWarning(precipitation, trendencyPr, trendencyWl);
+    const qrSrc = this.getQrURL();
     return {
       precipitation,
       trendencyPr,
       trendencyWl,
       warning,
+      qrSrc,
     };
   }
-
-  getQrCode () {
-    // ここでURLを生成するロジックを書く
-    return {
-      src: 'http://chart.apis.google.com/chart?chs=150x150&cht=qr&chl=http://lgtm.in/i/yFqM3iGVp'
-    };
-  }
-
   getLocation () {
     return {
       current: this.getCurrentLocation(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,6 +114,15 @@ module.exports = class Lib {
       warning,
     };
   }
+
+  getQrCode () {
+    // objectにしてreturnするときは、こうしないとエラーになる
+    const src = 'http://chart.apis.google.com/chart?chs=150x150&cht=qr&chl=http://lgtm.in/i/yFqM3iGVp';
+    return {
+      src,
+    };
+  }
+
   getLocation () {
     return {
       current: this.getCurrentLocation(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -113,9 +113,13 @@ module.exports = class Lib {
     return '';
   }
   getQrURL () {
+    const { latitude, longitude } = this.geolocation;
+
+    // err handling
+    if (latitude === 999 || longitude === 999) return '';
+
     const destination = '入江タリーズ'; // TODO: 引数で受け取れるようにする
-    console.log(this.geolocation.latitude, this.geolocation.longitude);
-    const chl = `https://www.google.co.jp/maps/dir/${ this.geolocation.latitude },${ this.geolocation.longitude }/${encodeURIComponent(destination)}/`;
+    const chl = `https://www.google.co.jp/maps/dir/${latitude},${longitude}/${encodeURIComponent(destination)}/`;
     return `http://chart.apis.google.com/chart?chs=${this.qrsize}x${this.qrsize}&cht=qr&chl=${chl}`;
   }
   getData () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,10 +116,9 @@ module.exports = class Lib {
   }
 
   getQrCode () {
-    // objectにしてreturnするときは、こうしないとエラーになる
-    const src = 'http://chart.apis.google.com/chart?chs=150x150&cht=qr&chl=http://lgtm.in/i/yFqM3iGVp';
+    // ここでURLを生成するロジックを書く
     return {
-      src,
+      src: 'http://chart.apis.google.com/chart?chs=150x150&cht=qr&chl=http://lgtm.in/i/yFqM3iGVp'
     };
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,12 @@ module.exports = class Lib {
     this.prefecture = prefecture;
     this.river = river;
   }
+  setGeolocation ({ latitude = this.latitude, longitude = this.longitude }) {
+    this.geolocation = {
+      latitude,
+      longitude,
+    };
+  }
   getCurrentLocation () {
     return { country: this.country, prefecture: this.prefecture, river: this.river };
   }

--- a/main.js
+++ b/main.js
@@ -57,7 +57,6 @@ app.on('ready', () => {
       // View Reflect
       win.webContents.send('dataReflect', lib.getData());
       win.webContents.send('locationReflect', lib.getLocation());
-      win.webContents.send('qrCodeReflect', lib.getQrCode());
     }
   });
 
@@ -86,5 +85,4 @@ app.on('ready', () => {
 
   // Run Polling
   lib.polling(appIcon, '* */10 * * * *');
-  win.openDevTools();
 });

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ electronReload(__dirname);
 // Electron obj
 let appIcon = null;
 let win = null;
+process.env.GOOGLE_API_KEY = '';
 
 // init
 app.on('ready', () => {

--- a/main.js
+++ b/main.js
@@ -57,6 +57,7 @@ app.on('ready', () => {
       // View Reflect
       win.webContents.send('dataReflect', lib.getData());
       win.webContents.send('locationReflect', lib.getLocation());
+      win.webContents.send('qrCodeReflect', lib.getQrCode());
     }
   });
 
@@ -85,4 +86,5 @@ app.on('ready', () => {
 
   // Run Polling
   lib.polling(appIcon, '* */10 * * * *');
+  win.openDevTools();
 });

--- a/main.js
+++ b/main.js
@@ -66,6 +66,11 @@ app.on('ready', () => {
     win.webContents.send('locationReflect', lib.getLocation());
   });
 
+  // Update Geolocation
+  ipcMain.on('updateGeolocation', (e, geolocation) => {
+    lib.setGeolocation(geolocation);
+  });
+
   // Refresh
   ipcMain.on('refresh', () => {
     win.webContents.send('dataReflect', lib.getData());


### PR DESCRIPTION
対応Issue：https://github.com/Noah0x0/noah/issues/25

https://github.com/Noah0x0/noah/pull/49
こちらを元にさせてもらいました。

ひとまず以下２つを作成

- GeolocationAPIを使って現在地の緯度経度をメインプロセス側に保持
- メインプロセス側で保持しているデータを元にして、QRコードを画面上に描画

# 処理の流れ

### 立ち上げ時

- 一番最初newした時に初期値でメインプロセス側に保持される
- レンダープロセスが最初に実行されたときに、`app.js`のcomponentWillMountで`updateGeolocation`を叩いてGeolocationを拾う
- メインプロセスへ送信
- `lib.setGeolocation`で、受け取った値を保持（更新）
- 保持している値を元にしてQR用URLを`getQrURL`で生成
- `getData`でUIが取得
- QrCodeコンポーネントで表示

---

### 更新時

- 更新ボタンを押した時に`updateGeolocation`を叩く
- （以降は立ち上げ時と同じ）