### PR TITLE
Click notification to show window

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,9 +51,10 @@ const setTrayIconForWaterLevel = (waterLevel, appIcon = null) => {
 
 const generateNotify = () => {
   return notifier.notify({
-    'title': '警告',
-    'message': '水位が急上昇しています!',
-    'icon': constants.pushIcon,
+    title: '警告',
+    message: '水位が急上昇しています!',
+    icon: constants.pushIcon,
+    wait: true,
   });
 };
 

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@
 const { app, Tray, BrowserWindow, ipcMain } = require('electron');
 const openAboutWindow = require('about-window').default;
 const electronReload = require('electron-reload');
+const notifier = require('node-notifier');
 const Lib = require('./lib/');
 const constants = require('./constants');
 
@@ -53,11 +54,12 @@ app.on('ready', () => {
       win.hide();
     } else {
       win.show();
-
-      // View Reflect
-      win.webContents.send('dataReflect', lib.getData());
-      win.webContents.send('locationReflect', lib.getLocation());
     }
+  });
+
+  win.on('show', () => {
+    win.webContents.send('dataReflect', lib.getData());
+    win.webContents.send('locationReflect', lib.getLocation());
   });
 
   // Update Location
@@ -82,6 +84,9 @@ app.on('ready', () => {
       width: 550,
     }
   }));
+
+  // Click notification to show window
+  notifier.on('click', () => win.show());
 
   // Run Polling
   lib.polling(appIcon, '* */10 * * * *');


### PR DESCRIPTION
https://github.com/Noah0x0/noah/issues/42
Issue fix

---

- notifierのclickイベントにwin.show()を紐付け
- dataの反映タイミングを、appIconのclickイベントではなく、winのshowイベントに移動
- notifierのclickを有効にするために、`wait: true` を指定する